### PR TITLE
Making setup work with different username than "pi"

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ git clone https://github.com/mundeepl/PiFM
 ```
 This will download the software from this repository
 ```
-chmod +x /home/pi/PiFM/setup-pi4.sh
+chmod +x /home/<your_username>/PiFM/setup-pi4.sh
 ```
 This changes the permissions to allow you to run the setup
 ```
@@ -75,7 +75,7 @@ git clone https://github.com/mundeepl/PiFM
 ```
 This will download the software from this repository
 ```
-chmod +x /home/pi/PiFM/setup.sh
+chmod +x /home/<your_username>/PiFM/setup.sh
 ```
 This changes the permissions to allow you to run the setup
 ```

--- a/pifm-basic.sh
+++ b/pifm-basic.sh
@@ -118,7 +118,8 @@ sleep 1
 echo -ne 'Completed. Starting service PiFM.  \r'
 echo -ne '\n'
 
-username=$(whoami)
+
 # starting the PiFM software with the chosen variable flags
+username=$(whoami)
 cd /home/$username/PiFM/src
 sudo ./pifm --freq $frequency --ps $ps --rt "$rt" --audio $audio --pi $pi --pty $pty --mpx $mpx --power $power --preemph $pre

--- a/pifm-basic.sh
+++ b/pifm-basic.sh
@@ -118,7 +118,7 @@ sleep 1
 echo -ne 'Completed. Starting service PiFM.  \r'
 echo -ne '\n'
 
-
+username=$(whoami)
 # starting the PiFM software with the chosen variable flags
-cd /home/pi/PiFM/src
+cd /home/$username/PiFM/src
 sudo ./pifm --freq $frequency --ps $ps --rt "$rt" --audio $audio --pi $pi --pty $pty --mpx $mpx --power $power --preemph $pre

--- a/pifm.sh
+++ b/pifm.sh
@@ -114,6 +114,7 @@ zenity --progress --title="PiFM by mundeepl" --percentage=0 --auto-close --auto-
 echo "Completed. Starting service Pi FM RDS"
 
 # Running Pi FM RDS
-cd /home/pi/PiFM/src
+username=$(whoami)
+cd /home/$username/PiFM/src
 sudo ./pifm --ps $ps --rt "$rt" --freq $frequency --audio $audio --preemph $region --pty $genre --power $power
 zenity --title="PiFM by mundeepl" --info --text="Transmission ended. Thank you for using the PiFM Transmission software that was developed by mundeepl. If you would like to use more advanced settings, be sure to check out the README file in the /home/pi/PiFM directory. This will teach you further arguements and how to use the command line." --width=500 --height=150 --ok-label="Exit"

--- a/setup-pi4.sh
+++ b/setup-pi4.sh
@@ -15,7 +15,8 @@ echo "Installing required tools" ; sleep 1
 sudo apt-get install libsndfile1-dev zenity git -y
 clear
 echo "Changing directory --> src" ; sleep 1
-cd /home/pi/PiFM/src
+username=$(whoami)
+cd /home/$username/PiFM/src
 clear
 echo "Cleaning up" ; sleep 1
 make clean
@@ -29,26 +30,26 @@ echo "Editing -> /boot/config.txt" ; sleep 1
 echo "gpu_freq=250" | sudo tee -a /boot/config.txt > /dev/null
 clear
 echo "Adding software" ; sleep 1
-cd /home/pi/PiFM
+cd /home/$username/PiFM
 # Copy GUI Version
-sudo cp /home/pi/PiFM/src/pi4/pifm.sh /usr/local/bin
+sudo cp /home/$username/PiFM/src/pi4/pifm.sh /usr/local/bin
 sudo mv /usr/local/bin/pifm.sh /usr/local/bin/pifm
 # Copy Basic Version
-sudo cp /home/pi/PiFM/src/pi4/pifm-basic.sh /usr/local/bin
+sudo cp /home/$username/PiFM/src/pi4/pifm-basic.sh /usr/local/bin
 sudo mv /usr/local/bin/pifm-basic.sh /usr/local/bin/pifm-basic
 clear
 echo "Creating shortcuts" ; sleep 1
-sudo cp /home/pi/PiFM/src/pi4/PiFM.desktop /home/pi/Desktop
-sudo cp /home/pi/PiFM/src/pi4/PiFM.desktop /usr/share/applications
+sudo cp /home/$username/PiFM/src/pi4/PiFM.desktop /home/$username/Desktop
+sudo cp /home/$username/PiFM/src/pi4/PiFM.desktop /usr/share/applications
 echo "Changing filename/type" ; sleep 0.1
-sudo mv /home/pi/PiFM/src/pi_fm_adv /home/pi/PiFM/src/pifm
+sudo mv /home/$username/PiFM/src/pi_fm_adv /home/$username/PiFM/src/pifm
 clear
 echo "Patching xterm" ; sleep 0.1
 cd /usr/bin
 sudo cp lxterminal xterm
 clear
 echo "Assigning permissions" ; sleep 0.1
-sudo chmod +x /home/pi/PiFM/pifm
+sudo chmod +x /home/$username/PiFM/pifm
 sudo chmod +x /usr/local/bin/pifm
 sudo chmod +x /usr/local/bin/pifm-basic
 clear

--- a/setup-pi4.sh
+++ b/setup-pi4.sh
@@ -55,6 +55,9 @@ sudo chmod +x /usr/local/bin/pifm-basic
 clear
 echo "Completed" ; sleep 2
 clear
+if [ $username != "pi" ]; then
+  sed -i "s|/pi/|/$username/|" /home/$username/Desktop/PiFM.desktop
+fi
 echo "To start broadcasting, use the start menu/desktop shortcuts,"
 echo "or type radio into the terminal. Preparing reboot..."
 sleep 5

--- a/setup-pi4.sh
+++ b/setup-pi4.sh
@@ -53,11 +53,11 @@ sudo chmod +x /home/$username/PiFM/pifm
 sudo chmod +x /usr/local/bin/pifm
 sudo chmod +x /usr/local/bin/pifm-basic
 clear
-echo "Completed" ; sleep 2
-clear
 if [ $username != "pi" ]; then
   sed -i "s|/pi/|/$username/|" /home/$username/Desktop/PiFM.desktop
 fi
+echo "Completed" ; sleep 2
+clear
 echo "To start broadcasting, use the start menu/desktop shortcuts,"
 echo "or type radio into the terminal. Preparing reboot..."
 sleep 5

--- a/setup.sh
+++ b/setup.sh
@@ -15,7 +15,8 @@ echo "Installing required tools" ; sleep 1
 sudo apt-get install libsndfile1-dev zenity -y
 clear
 echo "Changing directory --> src" ; sleep 1
-cd /home/pi/PiFM/src
+username=$(whoami)
+cd /home/$username/PiFM/src
 clear
 echo "Cleaning up" ; sleep 1
 make clean
@@ -27,26 +28,26 @@ echo "Making adjustments to --> /boot/config.txt" ; sleep 1
 echo "gpu_freq=250" | sudo tee -a /boot/config.txt > /dev/null
 clear
 echo "Adding software" ; sleep 1
-cd /home/pi/PiFM
+cd /home/$username/PiFM
 # Copy GUI Version
-sudo cp /home/pi/PiFM/pifm.sh /usr/local/bin
+sudo cp /home/$username/PiFM/pifm.sh /usr/local/bin
 sudo mv /usr/local/bin/pifm.sh /usr/local/bin/pifm
 # Copy Basic Version
-sudo cp /home/pi/PiFM/pifm-basic.sh /usr/local/bin
+sudo cp /home/$username/PiFM/pifm-basic.sh /usr/local/bin
 sudo mv /usr/local/bin/pifm-basic.sh /usr/local/bin/pifm-basic
 clear
 echo "Creating shortcuts" ; sleep 1
-sudo cp /home/pi/PiFM/src/PiFM.desktop /home/pi/Desktop
-sudo cp /home/pi/PiFM/src/PiFM.desktop /usr/share/applications
+sudo cp /home/$username/PiFM/src/PiFM.desktop /home/$username/Desktop
+sudo cp /home/$username/PiFM/src/PiFM.desktop /usr/share/applications
 echo "Changing filename/type" ; sleep 1
-sudo mv /home/pi/PiFM/src/pi_fm_adv /home/pi/PiFM/src/pifm
+sudo mv /home/$username/PiFM/src/pi_fm_adv /home/$username/PiFM/src/pifm
 clear
 echo "Patching xterm" ; sleep 1
 cd /usr/bin
 sudo cp lxterminal xterm
 clear
 echo "Assigning permissions" ; sleep 1
-sudo chmod +x /home/pi/PiFM/pifm
+sudo chmod +x /home/$username/PiFM/pifm
 sudo chmod +x /usr/local/bin/pifm
 sudo chmod +x /usr/local/bin/pifm-basic
 clear

--- a/setup.sh
+++ b/setup.sh
@@ -51,6 +51,9 @@ sudo chmod +x /home/$username/PiFM/pifm
 sudo chmod +x /usr/local/bin/pifm
 sudo chmod +x /usr/local/bin/pifm-basic
 clear
+if [ $username != "pi" ]; then
+  sed -i "s|/pi/|/$username/|" /home/$username/Desktop/PiFM.desktop
+fi
 echo "Completed" ; sleep 2
 clear
 echo "To start broadcasting, use the menu or desktop shortcuts,"


### PR DESCRIPTION
In the latest versions of PiOS, it encourages to make different default super user name than "pi". If it is different setup.sh fails to install PiFM completely.  With changes I have added it allows correct installation regardless of username.